### PR TITLE
Updated Login form to fix main logo floating issue

### DIFF
--- a/Home.css
+++ b/Home.css
@@ -8,7 +8,8 @@ body {
 }
 
 #login {
-	float: right;
+	position: absolute;
+	right: 0;
 }
 
 img {


### PR DESCRIPTION
With `float`, other elements adjust to fill the remaining space. I used `position: absolute` instead, to make the positioning of the login form independent of the logo and the rest of the page, then aligned it to the right edge with `right: 0`.