### PR TITLE
Removed extraneous '1' to restore background color

### DIFF
--- a/Home.css
+++ b/Home.css
@@ -1,4 +1,4 @@
-1* {
+* {
 	background-color: rgb(238, 235, 231);
 }
 


### PR DESCRIPTION
Apparently, I accidentally typed a `1` at the start of the file in my last commit, making it so the background color wasn't applied.
That's what I'm fixing.